### PR TITLE
Fix FSM repeatedly toggling between RLFSMStateGetDown and RLFSMStateGetUp

### DIFF
--- a/src/rl_sar/library/core/rl_sdk/rl_sdk.hpp
+++ b/src/rl_sar/library/core/rl_sdk/rl_sdk.hpp
@@ -95,8 +95,8 @@ namespace Input
 
 struct Control
 {
-    Input::Keyboard current_keyboard, last_keyboard;
-    Input::Gamepad current_gamepad, last_gamepad;
+    Input::Keyboard current_keyboard = Input::Keyboard::None, last_keyboard = Input::Keyboard::None;
+    Input::Gamepad current_gamepad = Input::Gamepad::None, last_gamepad = Input::Gamepad::None;
 
     double x = 0.0;
     double y = 0.0;


### PR DESCRIPTION
In rl_sar/src/rl_sar/library/core/rl_sdk/rl_sdk.hpp, the Input::Gamepad members current_gamepad and last_gamepad inside the Control struct were uninitialized before use. When the /joy topic was not subscribed, their values were random. In the current version, they happened to be initialized to Input::Gamepad::B, which caused repeated state toggling.