### PR TITLE
feat: add Docker support for simulation and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ git clone https://github.com/osrf/gazebo_models.git ~/.gazebo/models
 # Example: ./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
 ```
 
+#### Docker
+
+Docker support is available for simulation and deployment. See [docker/README.md](docker/README.md) for details.
+
+```bash
+# Start container
+xhost +local:docker  # Enable X11 on host
+cd docker && docker compose up -d
+docker compose exec rl_sar bash
+
+# Inside container - MuJoCo
+./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
+
+# Inside container - Gazebo
+ros2 launch rl_sar gazebo.launch.py rname:=go2
+# (new terminal) ros2 run rl_sar rl_sim
+
+# Inside container - Real robot
+./cmake_build/bin/rl_real_go2 <NETWORK_INTERFACE>
+```
+
 ### Control with Mobile Web (Experimental)
 
 Install dependencies

--- a/README_CN.md
+++ b/README_CN.md
@@ -195,6 +195,27 @@ git clone https://github.com/osrf/gazebo_models.git ~/.gazebo/models
 # Example: ./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
 ```
 
+#### Docker
+
+Docker支持仿真和部署。详见 [docker/README.md](docker/README.md)。
+
+```bash
+# 启动容器
+xhost +local:docker  # 在主机上启用X11
+cd docker && docker compose up -d
+docker compose exec rl_sar bash
+
+# 容器内 - MuJoCo仿真
+./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
+
+# 容器内 - Gazebo仿真
+ros2 launch rl_sar gazebo.launch.py rname:=go2
+# (新终端) ros2 run rl_sar rl_sim
+
+# 容器内 - 真实机器人
+./cmake_build/bin/rl_real_go2 <NETWORK_INTERFACE>
+```
+
 ### 使用手机网页控制 (实验性)
 
 安装依赖

--- a/build.sh
+++ b/build.sh
@@ -69,6 +69,17 @@ setup_robot_descriptions() {
     fi
 }
 
+setup_gazebo_models() {
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+    DOWNLOAD_GAZEBO_MODELS_SCRIPT="${SCRIPT_DIR}/scripts/download_gazebo_models.sh"
+
+    if [ -f "$DOWNLOAD_GAZEBO_MODELS_SCRIPT" ]; then
+        bash "$DOWNLOAD_GAZEBO_MODELS_SCRIPT" || {
+            print_warning "Gazebo models setup skipped (optional for simulation)"
+        }
+    fi
+}
+
 run_cmake_build() {
     print_header "[Running CMake Build]"
     print_warning "NOTE: CMake build is for hardware deployment only, not for simulation."
@@ -397,6 +408,7 @@ main() {
 
     setup_inference_runtime
     setup_robot_descriptions
+    setup_gazebo_models
     run_ros_build "${packages[@]}"
 }
 

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,32 @@
+# Ignore build artifacts (will be rebuilt inside container)
+cmake_build/
+build/
+install/
+devel/
+log/
+logs/
+.catkin_tools/
+
+# Downloaded libraries (will be re-downloaded)
+library/
+
+# Git (repo cloned fresh in Docker)
+.git/
+.gitignore
+.gitmodules
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Source code (cloned from GitHub in Docker)
+src/
+scripts/
+VERSION
+*.md
+
+# Keep policy and docker folders
+!policy/
+!docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,105 @@
+# rl_sar Docker Image
+# ROS2 Humble + Gazebo + MuJoCo + Real Robot Support
+#
+# Build from repo root:
+#   docker build -f docker/Dockerfile -t rl_sar:humble .
+#
+# Or use docker compose:
+#   cd docker && docker compose up
+#
+FROM ros:humble-ros-base-jammy
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies (from README.md)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    g++ \
+    build-essential \
+    libyaml-cpp-dev \
+    libeigen3-dev \
+    libboost-all-dev \
+    libspdlog-dev \
+    libfmt-dev \
+    libtbb-dev \
+    liblcm-dev \
+    # For downloads
+    curl \
+    wget \
+    unzip \
+    # For GUI (MuJoCo visualization)
+    libgl1-mesa-glx \
+    libglfw3 \
+    libglfw3-dev \
+    libxrandr2 \
+    libxinerama1 \
+    libxcursor1 \
+    libxi6 \
+    # Mesa/EGL for GPU rendering
+    libgl1-mesa-dri \
+    libegl1 \
+    libegl1-mesa \
+    libglvnd-dev \
+    mesa-utils \
+    # Gamepad support
+    joystick \
+    jstest-gtk \
+    # Utilities
+    git \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create NVIDIA EGL ICD config for GPU rendering
+RUN mkdir -p /usr/share/glvnd/egl_vendor.d && \
+    printf '{"file_format_version":"1.0.0","ICD":{"library_path":"libEGL_nvidia.so.0"}}' \
+    > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+
+# NVIDIA container environment
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
+
+# ROS2 packages for robot control
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-humble-teleop-twist-keyboard \
+    ros-humble-ros2-control \
+    ros-humble-ros2-controllers \
+    ros-humble-control-toolbox \
+    ros-humble-robot-state-publisher \
+    ros-humble-joint-state-publisher-gui \
+    ros-humble-xacro \
+    ros-humble-joy \
+    # For parameter_blackboard used in gazebo.launch.py
+    ros-humble-demo-nodes-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Gazebo simulation packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-humble-gazebo-ros2-control \
+    ros-humble-gazebo-ros-pkgs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download Gazebo models (sun, ground_plane) using sparse checkout
+RUN mkdir -p /root/.gazebo/models && \
+    cd /root/.gazebo/models && \
+    git clone --depth 1 --filter=blob:none --sparse \
+        https://github.com/osrf/gazebo_models.git . && \
+    git sparse-checkout set sun ground_plane
+
+# Create workspace
+WORKDIR /rl_sar
+
+# Copy local source (requires: git submodule update --init --recursive)
+COPY . .
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Build ROS2 workspace (for Gazebo simulation)
+# Must source ROS2 setup first for colcon to find ament_cmake
+SHELL ["/bin/bash", "-c"]
+RUN source /opt/ros/humble/setup.bash && ./build.sh
+
+# Build MuJoCo (for MuJoCo simulation + real robot executables)
+RUN ./build.sh -mj
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,117 @@
+# Docker Support for rl_sar
+
+Docker environment for simulation and deployment with ROS2 Humble.
+
+## Prerequisites
+
+Before building, initialize git submodules:
+```bash
+git submodule update --init --recursive
+```
+
+## Quick Start
+
+```bash
+# Enable X11 forwarding (on host)
+xhost +local:docker
+
+# Build and run (from repo root or docker/ directory)
+cd docker
+docker compose up -d
+
+# To use software rendering (Mesa llvmpipe) instead of GPU:
+# docker compose --profile software up -d rl_sar_software
+
+# Check which renderer is used:
+# docker exec -it rl_sar glxinfo | grep "OpenGL renderer"
+#   GPU mode:      NVIDIA GeForce RTX xxxx
+#   Software mode: llvmpipe (LLVM xx.x, 256 bits)
+
+# Rebuild after code changes, if only change policies not codes, no need to rebuild
+docker compose up -d --build
+
+# in the docker folder
+docker compose exec rl_sar bash
+# or anywhere
+docker exec -it rl_sar bash
+```
+
+## Usage
+
+### MuJoCo Simulation
+
+```bash
+./cmake_build/bin/rl_sim_mujoco <ROBOT> <SCENE>
+# Example:
+./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
+./cmake_build/bin/rl_sim_mujoco go2 scene
+```
+
+### Gazebo Simulation
+
+```bash
+# Terminal 1: Launch Gazebo
+source install/setup.bash
+ros2 launch rl_sar gazebo.launch.py rname:=<ROBOT>
+
+# Example:
+source install/setup.bash
+ros2 launch rl_sar gazebo.launch.py rname:=g1
+
+# Terminal 2: Run controller
+source install/setup.bash
+ros2 run rl_sar rl_sim
+
+# Terminal 3: control via ros topic
+# Press N to enter navigation mode
+source install/setup.bash
+ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.5}}" -r 10
+# Note, current impl won't stop if the message is not received for a while, press N again to exit navigation mode
+
+```
+
+### Real Robot
+
+```bash
+# Go2/Go2W
+./cmake_build/bin/rl_real_go2 <NETWORK_INTERFACE> [wheel]
+
+# G1 (29dofs)
+./cmake_build/bin/rl_real_g1 <NETWORK_INTERFACE>
+
+# A1
+./cmake_build/bin/rl_real_a1
+```
+
+## Controls
+
+| Gamepad | Keyboard | Description |
+|---------|----------|-------------|
+| A | Num0 | Stand up (move to default pose) |
+| B | Num9 | Return to initial pose |
+| RB+DPadUp | Num1 | Basic locomotion |
+| LY/LX | W/S, A/D | Move forward/backward, left/right |
+| RX | Q/E | Yaw rotation |
+| RB+Y | R | Reset simulation (Gazebo) |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `Dockerfile` | ROS2 Humble + Gazebo + MuJoCo + Real Robot |
+| `docker-compose.yml` | X11 + gamepad + network support |
+| `entrypoint.sh` | Sources ROS2 setup |
+
+## Build Manually
+
+```bash
+# From repo root
+docker build -f docker/Dockerfile -t rl_sar:humble .
+```
+
+## Notes
+
+- Gazebo models (sun, ground_plane) are automatically downloaded during build
+- Policy files are mounted read-only from `../policy`
+- Container runs in privileged mode with host network for robot communication
+- Gamepad devices are passed through via `/dev/input`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,63 @@
+# rl_sar Docker Compose
+#
+# Usage (from docker/ directory):
+#   docker compose up -d             # Start container
+#   docker compose exec rl_sar bash  # Enter container
+#
+#   # Run MuJoCo simulation
+#   ./cmake_build/bin/rl_sim_mujoco g1 scene_29dof
+#
+# GUI Setup (run on host first):
+#   xhost +local:docker
+#
+# Rendering modes:
+#   GPU (default):      docker compose up -d
+#   Software only:      docker compose --profile software up -d rl_sar_software
+#   Switch to software: docker compose down && docker compose --profile software up -d rl_sar_software
+#
+# Common configuration anchor
+x-common: &common
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile
+  image: rl_sar:humble
+  network_mode: host
+  stdin_open: true
+  tty: true
+  environment:
+    - DISPLAY=${DISPLAY}
+    - QT_X11_NO_MITSHM=1
+    - MESA_GL_VERSION_OVERRIDE=${MESA_GL_VERSION_OVERRIDE:-3.3}
+  volumes:
+    - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    - ${HOME}/.Xauthority:/root/.Xauthority:rw
+    - ../policy:/rl_sar/policy:ro
+  devices:
+    - /dev/input:/dev/input
+  command: bash
+
+services:
+  # GPU mode (default) - with NVIDIA runtime and full device access
+  rl_sar:
+    <<: *common
+    container_name: rl_sar
+    runtime: nvidia
+    privileged: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - MESA_GL_VERSION_OVERRIDE=${MESA_GL_VERSION_OVERRIDE:-3.3}
+
+  # Software mode - no NVIDIA runtime, Mesa llvmpipe rendering
+  rl_sar_software:
+    <<: *common
+    container_name: rl_sar_sw
+    profiles: ["software"]
+    privileged: true
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+      - LIBGL_ALWAYS_SOFTWARE=1
+      - MESA_GL_VERSION_OVERRIDE=${MESA_GL_VERSION_OVERRIDE:-3.3}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Source ROS2 setup
+source /opt/ros/humble/setup.bash
+
+# Source local workspace if built with ROS
+if [ -f /rl_sar/install/setup.bash ]; then
+    source /rl_sar/install/setup.bash
+fi
+
+exec "$@"

--- a/scripts/download_gazebo_models.sh
+++ b/scripts/download_gazebo_models.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Automatic download script for Gazebo models
+# Downloads only required models (sun, ground_plane) using sparse checkout
+# Usage: ./download_gazebo_models.sh
+
+set -e
+
+# Get script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Load common utilities
+source "${SCRIPT_DIR}/common.sh"
+
+# Configuration
+GAZEBO_MODEL_DIR="$HOME/.gazebo/models"
+REQUIRED_MODELS=("sun" "ground_plane")
+GAZEBO_MODELS_REPO="https://github.com/osrf/gazebo_models.git"
+
+# Check if all required models exist
+are_models_valid() {
+    for model in "${REQUIRED_MODELS[@]}"; do
+        if [ ! -d "$GAZEBO_MODEL_DIR/$model" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+# Download models using sparse checkout
+download_models() {
+    print_info "Downloading Gazebo models (sun, ground_plane)..."
+    mkdir -p "$GAZEBO_MODEL_DIR"
+    cd "$GAZEBO_MODEL_DIR"
+
+    if [ -d ".git" ]; then
+        # Already a git repo, update sparse checkout
+        print_info "Updating existing Gazebo models..."
+        git sparse-checkout set "${REQUIRED_MODELS[@]}"
+        git pull --depth 1 origin master || true
+    else
+        # Fresh clone with sparse checkout
+        print_info "Cloning Gazebo models repository..."
+        git clone --depth 1 --filter=blob:none --sparse \
+            "$GAZEBO_MODELS_REPO" .
+        git sparse-checkout set "${REQUIRED_MODELS[@]}"
+    fi
+}
+
+# Main
+print_header "[Gazebo Models Setup]"
+
+if are_models_valid; then
+    print_success "Gazebo models already exist at $GAZEBO_MODEL_DIR"
+    exit 0
+fi
+
+if ! is_online; then
+    print_warning "Network unavailable, skipping Gazebo models download"
+    print_info "You can manually download models later:"
+    print_info "  git clone https://github.com/osrf/gazebo_models.git ~/.gazebo/models"
+    exit 0
+fi
+
+download_models
+
+if are_models_valid; then
+    print_success "Gazebo models setup completed!"
+else
+    print_error "Failed to download Gazebo models"
+    exit 1
+fi


### PR DESCRIPTION
Hi,

Thanks for this repo.

In my local dev machine, the mujoco works nicely on the machine, but somehow the gazebo env will crash all my window.

Provide one docker env should be not bad:

* mujoco works
* gazebo works
* ROS `/cmd_vel` control works

****

The mujoco:

<img width="1167" height="956" alt="image" src="https://github.com/user-attachments/assets/645b8466-65c2-4545-833c-d7c415939745" />


The gazebo:

<img width="1027" height="834" alt="image" src="https://github.com/user-attachments/assets/7a083098-34a1-4b1a-92c6-18074da0d3a6" />

****
