### PR TITLE
# PR: SetCommand unified as "fresh command per write" coding convention

### DIFF
--- a/src/rl_sar/src/rl_real_a1.cpp
+++ b/src/rl_sar/src/rl_real_a1.cpp
@@ -144,19 +144,25 @@ void RL_Real::GetState(RobotState<float> *state)
 
 void RL_Real::SetCommand(const RobotCommand<float> *command)
 {
+    UNITREE_LEGGED_SDK::LowCmd cmd = {0};
+    this->unitree_udp.InitCmdData(cmd);
+
     for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
     {
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode = 0x0A;
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].q = command->motor_command.q[i];
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq = command->motor_command.dq[i];
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kp = command->motor_command.kp[i];
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kd = command->motor_command.kd[i];
-        this->unitree_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau = command->motor_command.tau[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode = 0x0A;
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].q = command->motor_command.q[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq = command->motor_command.dq[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kp = command->motor_command.kp[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kd = command->motor_command.kd[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau = command->motor_command.tau[i];
     }
 
-    this->unitree_safe.PowerProtect(this->unitree_low_command, this->unitree_low_state, 8);
-    // this->unitree_safe.PositionProtect(this->unitree_low_command, this->unitree_low_state);
-    this->unitree_udp.SetSend(this->unitree_low_command);
+    this->unitree_safe.PowerProtect(cmd, this->unitree_low_state, 8);
+    this->unitree_udp.SetSend(cmd);
+
+#ifdef PLOT
+    this->unitree_low_command = cmd;
+#endif
 }
 
 void RL_Real::RobotControl()

--- a/src/rl_sar/src/rl_real_g1.cpp
+++ b/src/rl_sar/src/rl_real_g1.cpp
@@ -171,21 +171,26 @@ void RL_Real::GetState(RobotState<float> *state)
 
 void RL_Real::SetCommand(const RobotCommand<float> *command)
 {
-    this->unitree_low_command.mode_pr() = static_cast<uint8_t>(this->mode_pr);
-    this->unitree_low_command.mode_machine() = this->mode_machine;
+    LowCmd_ dds_low_command;
+    dds_low_command.mode_pr() = static_cast<uint8_t>(this->mode_pr);
+    dds_low_command.mode_machine() = this->mode_machine;
 
     for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
     {
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode() = 1; // 1:Enable, 0:Disable
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].q() = command->motor_command.q[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq() = command->motor_command.dq[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp() = command->motor_command.kp[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd() = command->motor_command.kd[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau() = command->motor_command.tau[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode() = 1;
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].q() = command->motor_command.q[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq() = command->motor_command.dq[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp() = command->motor_command.kp[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd() = command->motor_command.kd[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau() = command->motor_command.tau[i];
     }
 
-    this->unitree_low_command.crc() = Crc32Core((uint32_t *)&unitree_low_command, (sizeof(LowCmd_) >> 2) - 1);
-    lowcmd_publisher->Write(unitree_low_command);
+    dds_low_command.crc() = Crc32Core((uint32_t *)&dds_low_command, (sizeof(LowCmd_) >> 2) - 1);
+    lowcmd_publisher->Write(dds_low_command);
+
+#ifdef PLOT
+    this->unitree_low_command = dds_low_command;
+#endif
 }
 
 void RL_Real::RobotControl()

--- a/src/rl_sar/src/rl_real_go2.cpp
+++ b/src/rl_sar/src/rl_real_go2.cpp
@@ -164,18 +164,38 @@ void RL_Real::GetState(RobotState<float> *state)
 
 void RL_Real::SetCommand(const RobotCommand<float> *command)
 {
-    for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
+    unitree_go::msg::dds_::LowCmd_ dds_low_command;
+    dds_low_command.head()[0] = 0xFE;
+    dds_low_command.head()[1] = 0xEF;
+    dds_low_command.level_flag() = 0xFF;
+    dds_low_command.gpio() = 0;
+
+    for (int i = 0; i < 20; ++i)
     {
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode() = 0x01;
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].q() = command->motor_command.q[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq() = command->motor_command.dq[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp() = command->motor_command.kp[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd() = command->motor_command.kd[i];
-        this->unitree_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau() = command->motor_command.tau[i];
+        dds_low_command.motor_cmd()[i].mode() = 0x01;
+        dds_low_command.motor_cmd()[i].q() = PosStopF;
+        dds_low_command.motor_cmd()[i].kp() = 0;
+        dds_low_command.motor_cmd()[i].dq() = VelStopF;
+        dds_low_command.motor_cmd()[i].kd() = 0;
+        dds_low_command.motor_cmd()[i].tau() = 0;
     }
 
-    this->unitree_low_command.crc() = Crc32Core((uint32_t *)&unitree_low_command, (sizeof(unitree_go::msg::dds_::LowCmd_) >> 2) - 1);
-    lowcmd_publisher->Write(unitree_low_command);
+    for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
+    {
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode() = 0x01;
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].q() = command->motor_command.q[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq() = command->motor_command.dq[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp() = command->motor_command.kp[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd() = command->motor_command.kd[i];
+        dds_low_command.motor_cmd()[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau() = command->motor_command.tau[i];
+    }
+
+    dds_low_command.crc() = Crc32Core((uint32_t *)&dds_low_command, (sizeof(unitree_go::msg::dds_::LowCmd_) >> 2) - 1);
+    lowcmd_publisher->Write(dds_low_command);
+
+#ifdef PLOT
+    this->unitree_low_command = dds_low_command;
+#endif
 }
 
 void RL_Real::RobotControl()

--- a/src/rl_sar/src/rl_real_l4w4.cpp
+++ b/src/rl_sar/src/rl_real_l4w4.cpp
@@ -165,17 +165,24 @@ void RL_Real::GetState(RobotState<float> *state)
 
 void RL_Real::SetCommand(const RobotCommand<float> *command)
 {
+    LowCmd cmd = {0};
+    this->l4w4_sdk.InitCmdData(cmd);
+
     for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
     {
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode = 0x0A;
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].q = command->motor_command.q[i];
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq = command->motor_command.dq[i];
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kp = command->motor_command.kp[i];
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kd = command->motor_command.kd[i];
-        this->l4w4_low_command.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau = command->motor_command.tau[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].mode = 0x0A;
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].q = command->motor_command.q[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].dq = command->motor_command.dq[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kp = command->motor_command.kp[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].Kd = command->motor_command.kd[i];
+        cmd.motorCmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].tau = command->motor_command.tau[i];
     }
 
-    this->l4w4_sdk.SendUDP(this->l4w4_low_command);
+    this->l4w4_sdk.SendUDP(cmd);
+
+#ifdef PLOT
+    this->l4w4_low_command = cmd;
+#endif
 }
 
 void RL_Real::RobotControl()

--- a/src/rl_sar/src/rl_real_lite3.cpp
+++ b/src/rl_sar/src/rl_real_lite3.cpp
@@ -160,16 +160,22 @@ void RL_Real::GetState(RobotState<float> *state)
 
 void RL_Real::SetCommand(const RobotCommand<float> *command)
 {
+    RobotCmd cmd = {};
+
     for (int i = 0; i < this->params.Get<int>("num_of_dofs"); ++i)
     {
-        this->robot_joint_cmd_.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].position = command->motor_command.q[i];
-        this->robot_joint_cmd_.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].velocity = command->motor_command.dq[i];
-        this->robot_joint_cmd_.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp = command->motor_command.kp[i];
-        this->robot_joint_cmd_.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd = command->motor_command.kd[i];
-        this->robot_joint_cmd_.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].torque = command->motor_command.tau[i];
+        cmd.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].position = command->motor_command.q[i];
+        cmd.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].velocity = command->motor_command.dq[i];
+        cmd.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].kp = command->motor_command.kp[i];
+        cmd.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].kd = command->motor_command.kd[i];
+        cmd.joint_cmd[this->params.Get<std::vector<int>>("joint_mapping")[i]].torque = command->motor_command.tau[i];
     }
 
-    this->sender_->SendCmd(robot_joint_cmd_);
+    this->sender_->SendCmd(cmd);
+
+#ifdef PLOT
+    this->robot_joint_cmd_ = cmd;
+#endif
 }
 
 void RL_Real::RobotControl()


### PR DESCRIPTION
# PR: SetCommand 统一为「每次新建命令」的编程规范

## 问题 (Problem)

rl_sar 在 G1 23DOF / Go2 真机上的 lowcmd 发送不稳定，偶发命令未生效（机器人不跟随关节指令），而官方 demo（如 `g1_ankle_swing_example`、`go2_stand_example`）运行稳定。

## 根因 (Root cause，G1/Go2)

CRC 按原始内存计算，含结构体 padding。复用 unitree_low_command 时 padding 未写入，导致 crc_reuse != crc_fresh，机器人 CRC 校验失败丢弃命令。原分析：

- **官方** `g1_ankle_swing_example`：每次 Write 时在 `LowCommandWriter()` 内新建 `LowCmd_ dds_low_command` 局部变量，填充后 Write
- **rl_sar 原实现**：复用成员变量 `unitree_low_command` 进行填充后 Write

复用同一块命令结构体可能导致：
1. DDS 序列化/发送时的潜在脏数据或未覆盖字段
2. 与官方已验证的「每次新建」模式不一致，影响稳定性

## 编程规范 (Coding convention)

为避免类似问题并统一代码风格，**所有机型的 SetCommand 均改为「每次新建命令、填充后发送」**，避免复用成员变量：

- 避免 padding/未初始化导致校验错误
- 每次发送内容确定、无历史残留
- 与官方 demo 和常见实践一致

## 修复 (Fix)

在 `SetCommand()` 中改为每次新建命令局部变量，填充后发送。

涉及文件：

- `rl_real_g1.cpp`：`LowCmd_` (HG)
- `rl_real_go2.cpp`：`unitree_go::msg::dds_::LowCmd_`
- `rl_real_a1.cpp`：`UNITREE_LEGGED_SDK::LowCmd`
- `rl_real_lite3.cpp`：`RobotCmd`
- `rl_real_l4w4.cpp`：`LowCmd`

```cpp
// Before: 复用成员
this->unitree_low_command.mode_pr() = ...
lowcmd_publisher->Write(unitree_low_command);

// After: 每次新建 (align official)
LowCmd_ dds_low_command;
dds_low_command.mode_pr() = ...
lowcmd_publisher->Write(dds_low_command);
```

## 参考 (Reference)

- G1: `unitree_sdk2/example/g1/low_level/g1_ankle_swing_example.cpp`，每次新建 `LowCmd_ dds_low_command`
- Go2: `unitree_sdk2/example/go2/go2_stand_example.cpp`，使用 `low_cmd{}` 默认初始化

# PR: SetCommand unified as "fresh command per write" coding convention

## Problem

rl_sar experienced unstable lowcmd delivery on G1 23DOF / Go2 real robots—commands occasionally not taking effect (robot not following joint instructions)—while official demos (e.g. `g1_ankle_swing_example`, `go2_stand_example`) run stably.

## Root cause (G1/Go2)

CRC is computed over raw memory, including struct padding. When reusing `unitree_low_command`, padding was never written, so `crc_reuse != crc_fresh`; the robot’s CRC check failed and the command was discarded. Summary:

- **Official** `g1_ankle_swing_example`: creates a new `LowCmd_ dds_low_command` local variable inside `LowCommandWriter()` on each Write, fills it, then Writes
- **rl_sar original**: reused member `unitree_low_command`, filled and Wrote

Reusing the same command struct can lead to:
1. Potential stale or unwritten fields during DDS serialization/send
2. Inconsistency with the official “create fresh each time” pattern, affecting stability

## Coding convention

To avoid similar issues and unify style, **all robot types’ SetCommand now create a fresh command each time, fill it, then send**, instead of reusing a member variable:

- Avoid CRC/checksum errors from padding or uninitialized data
- Each send has well-defined content with no leftover state
- Aligns with official demos and common practice

## Fix

In `SetCommand()`, create a fresh local command variable, fill it, then send.

Files touched:

- `rl_real_g1.cpp`: `LowCmd_` (HG)
- `rl_real_go2.cpp`: `unitree_go::msg::dds_::LowCmd_`
- `rl_real_a1.cpp`: `UNITREE_LEGGED_SDK::LowCmd`
- `rl_real_lite3.cpp`: `RobotCmd`
- `rl_real_l4w4.cpp`: `LowCmd`

```cpp
// Before: reuse member
this->unitree_low_command.mode_pr() = ...
lowcmd_publisher->Write(unitree_low_command);

// After: create fresh each time (align with official)
LowCmd_ dds_low_command;
dds_low_command.mode_pr() = ...
lowcmd_publisher->Write(dds_low_command);
```

## Reference

- G1: `unitree_sdk2/example/g1/low_level/g1_ankle_swing_example.cpp`, creates `LowCmd_ dds_low_command` per write
- Go2: `unitree_sdk2/example/go2/go2_stand_example.cpp`, uses `low_cmd{}` default initialization



